### PR TITLE
fix: ignore npm install result as semantic-release-gh-pages-plugin ex…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /target
 /node_modules
 /.releaserc
+package.json
+package-lock.json


### PR DESCRIPTION
…pects package.json to exist but cargo publish doesn't like it not being in git.